### PR TITLE
Add basiq core API

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,9 @@ source 'https://rubygems.org'
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}" }
 
 # Specify your gem's dependencies in basiq.gemspec
+
+group :development, :test do
+  gem 'webmock', '~>1.24.0'
+end
+
 gemspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,24 @@
 PATH
   remote: .
   specs:
-    basiq (0.1.0)
-      faraday (~> 0.9)
+    basiq-sdk (0.1.0)
+      faraday (>= 0.9.1)
+      multi_json (>= 1.11.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.6.0)
+      public_suffix (>= 2.0.2, < 4.0)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
+    hashdiff (0.3.8)
+    multi_json (1.13.1)
     multipart-post (2.0.0)
+    public_suffix (3.0.3)
     rake (10.5.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -25,15 +33,21 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
+    safe_yaml (1.0.5)
+    webmock (1.24.6)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  basiq!
+  basiq-sdk!
   bundler (~> 1.17)
   rake (~> 10.0)
   rspec (~> 3.0)
+  webmock (~> 1.24.0)
 
 BUNDLED WITH
    1.17.1

--- a/basiq.gemspec
+++ b/basiq.gemspec
@@ -34,7 +34,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'faraday', '~> 0.9'
+  spec.add_dependency('faraday', '>= 0.9.1')
+  spec.add_dependency('multi_json', '>= 1.11.0')
 
   spec.add_development_dependency 'bundler', '~> 1.17'
   spec.add_development_dependency 'rake', '~> 10.0'

--- a/lib/basiq.rb
+++ b/lib/basiq.rb
@@ -1,5 +1,29 @@
 require 'basiq/version'
 
+require 'faraday'
+require 'multi_json'
+
+require 'basiq/entities/access_token'
+require 'basiq/entities/account'
+require 'basiq/entities/base'
+require 'basiq/entities/connection'
+require 'basiq/entities/image'
+require 'basiq/entities/institution'
+require 'basiq/entities/job'
+require 'basiq/entities/transaction'
+require 'basiq/entities/user'
+
+require 'basiq/authorizer'
+require 'basiq/client'
+require 'basiq/connection_query'
+require 'basiq/filter_builder'
+require 'basiq/parser'
+require 'basiq/query'
+require 'basiq/request'
+require 'basiq/response'
+require 'basiq/service_error'
+
+
 module Basiq
   class Error < StandardError; end
   # Your code goes here...

--- a/lib/basiq/authorizer.rb
+++ b/lib/basiq/authorizer.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Basiq
+  # Basiq::Authorizer
+  #
+  #   When working with Basiq APIs application will need to complete the
+  #   authentication process first before you can access any of the available resources.
+  #
+  #   The authentication process is fairly straight forward,
+  #   and simply requires you to exchange your API key for a token.
+  #
+  #   Once you obtain the token, you can call any of the available API services by
+  #   simply including the token in the Authorization header of each request.
+  #
+  #   NOTE : Tokens have a short lifespan and as such should not be stored permanently.
+  #          Once a token has expired your application will need to reauthenticate.
+  #
+  class Authorizer
+
+    # @param [String] api_key -
+    #   (optional) API key for your application(via the Developer Dashboard)
+    #
+    def initialize(api_key = nil)
+      @api_key = api_key || ENV['BASIQ_API_KEY']
+
+      raise ArgumentError, 'Invalid API key' if @api_key.nil?
+    end
+
+    # Retrieves the access token
+    #
+    def obtain_token
+      headers = {
+        'Authorization' => "Basic #{@api_key}",
+        'Content-Type' => 'application/x-www-form-urlencoded'
+      }
+
+      response = Basiq::Request.new('token').post(headers: headers)
+
+      return nil if response.nil?
+
+      parse_token(response.body)
+    end
+
+    private
+
+    def parse_token(data)
+      params = {
+        token: data[:access_token],
+        type: data[:token_type],
+        expires_in: data[:expires_in]
+      }
+
+      Basiq::Entities::AccessToken.new(params)
+    end
+  end
+end

--- a/lib/basiq/client.rb
+++ b/lib/basiq/client.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+module Basiq
+  # Basiq::Client
+  #
+  #   Client to interact with BASIQ API
+  #
+  class Client
+    # @param [String] api_key -
+    #   Unique API key grabbed for your application(via the Developer Dashboard)
+    #
+    def initialize(api_key)
+      @api_key = api_key
+      @access_token = nil
+    end
+
+    # Check client authorization
+    #   (access token validity)
+    #
+    def authorized?
+      !@access_token.nil? && @access_token.valid?
+    end
+
+    # Perform client authorization
+    #   (obtain or renew access token)
+    #
+    def authorize!
+      @access_token = Authorizer.new(@api_key).obtain_token
+    end
+
+    # Get accounts query to perform operations related to the accounts endpoint
+    #
+    def accounts(user_id)
+      build_query("users/#{user_id}/accounts")
+    end
+
+    # Get connections query to perform operations related to the connections endpoint
+    #
+    def connections(user_id)
+      endpoint = "users/#{user_id}/connections"
+
+      Basiq::ConnectionQuery.new(endpoint, headers, parser)
+    end
+
+    # Get transaction query to perform operations related to the transaction endpoint
+    #
+    def transactions(user_id)
+      build_query("users/#{user_id}/transactions")
+    end
+
+    # Get jobs query to perform operations related to the jobs endpoint
+    #
+    def jobs
+      build_query('jobs')
+    end
+
+    # Get user query to perform operations related to the users endpoint
+    #
+    def users
+      build_query('users')
+    end
+
+    # Get institutions query to perform operations related to the institutions endpoint
+    #
+    def institutions
+      build_query('institutions')
+    end
+
+    private
+
+    def build_query(endpoint)
+      Basiq::Query.new(endpoint, headers, parser)
+    end
+
+    def headers
+      { 'Authorization' => "Bearer #{@access_token.token}" }
+    end
+
+    def parser
+      Basiq::Parser.new
+    end
+  end
+end

--- a/lib/basiq/connection_query.rb
+++ b/lib/basiq/connection_query.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+require 'basiq/query'
+
+module Basiq
+  # Basiq::ConnectionQuery
+  #
+  #   Used to build and execute request to the basiq API
+  #     (connections specific operations)
+  #
+  class ConnectionQuery < Query
+    def initialize(endpoint, headers, parser, filter_builder = nil)
+      super(endpoint, headers, parser, filter_builder)
+    end
+
+    # Use this to create a new connection object.
+    #
+    # Returns the job object if the update succeeded.
+    # Returns an error if update parameters are invalid.
+    #
+    # @param [Hash] params - User credentials for the connected institution
+    #
+    # @option params [String] :login_id -
+    #   The users institution login ID
+    #
+    # @option params [String] :password -
+    #   The users institution password
+    #
+    # @option params [String] :security_code -
+    #   (conditional) User's institution security code.
+    #   Mandatory if required by institution's login process
+    #
+    # @option params [String] :secondary_login_id -
+    #   (conditional) User's institution secondary login id.
+    #   Mandatory if required by institution's login process
+    #
+    # @option params [String] :institution_id -
+    #   A string that uniquely identifies the institution.
+    #
+    # @raise [Basiq::ServiceError]
+    #
+    # @return [Basiq::Entities::Job]
+    #
+    def create(params)
+      body = compose_body(params)
+      response = Basiq::Request
+                 .new(@root_endpoint)
+                 .post(body: body, headers: headers)
+
+      @parser.parse(response.body)
+    end
+
+    # Updates the specified connection object by setting the values of the parameters passed.
+    # Any parameters not provided will be left unchanged.
+    #
+    # Returns the job object if the update succeeded.
+    # Returns an error if update parameters are invalid.
+    #
+    # @param [String] connection_id - Uniq connection identifier
+    #
+    # @param [Hash] params - for the connected institution
+    #
+    # @option params [String] :login_id -
+    #   The users institution login ID
+    #
+    # @option params [String] :password -
+    #   The users institution password
+    #
+    # @option params [String] :security_code -
+    #   (conditional) User's institution security code.
+    #   Mandatory if required by institution's login process
+    #
+    # @option params [String] :secondary_login_id -
+    #   (conditional) User's institution secondary login id.
+    #   Mandatory if required by institution's login process
+    #
+    # @raise [Basiq::ServiceError]
+    #
+    # @return [Basiq::Entities::Job]
+    #
+    def update(connection_id, params)
+      endpoint = "/#{@root_endpoint}/#{connection_id}"
+      body = compose_body(params).without('institution')
+
+      response = Basiq::Request
+                 .new(endpoint)
+                 .post(body: body, headers: headers)
+
+      @parser.parse(response.body)
+    end
+
+    # Use this to retrieve the latest financial data.
+    # Similar to when a connection is first created, the refresh resource will
+    # initiate the following series of steps to retrieve the latest
+    # financial data from the target institution:
+    #
+    #   1. verify-credentials   - The server will attempt to authenticate with
+    #                             the target institution using the supplied credentials.
+    #
+    #   2. retrieve-accounts    - The server will retrieve the complete list of
+    #                             accounts and their details
+    #                             e.g. account number, name and balances.
+    #
+    #   3. retrieve-transaction - The server will fetch the associated
+    #                             transactions for each of the accounts.
+    #
+    # @param [String] connection_id - The identifier of the connection to be refreshed.
+    #
+    # @raise [Basiq::ServiceError]
+    #
+    # @return [Basiq::Entities::Job]
+    #
+    def refresh(connection_id)
+      endpoint = "/#{@root_endpoint}/#{connection_id}/refresh"
+
+      response = Basiq::Request.new(endpoint).post(headers: headers)
+
+      @parser.parse(response.body)
+    end
+
+    # Use this to refresh of all connections.
+    # Check how to refresh a connection for more details.
+    #
+    # @raise [Basiq::ServiceError]
+    #
+    # @return [Array<Basiq::Entities::Job>]
+    #
+    def refresh_all
+      endpoint = "/#{@root_endpoint}/refresh"
+
+      response = Basiq::Request.new(endpoint).post(headers: headers)
+
+      @parser.parse(response.body)
+    end
+
+    private
+
+    def compose_body(params)
+      {
+        'loginId' => params[:login_id],
+        'password' => params[:password],
+        'securityCode' => params[:security_code],
+        'secondary_login_id' => params[:secondary_login_id],
+        'institution' => {
+          'id' => params[:institution_id]
+        }
+      }
+    end
+  end
+end

--- a/lib/basiq/entities/access_token.rb
+++ b/lib/basiq/entities/access_token.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'basiq/entities/base'
+
+module Basiq
+  module Entities
+    # Basiq::Entities::AccessToken
+    #
+    #   This access token is the key to making successful requests to the Basiq API.
+    #   You will need to include this access token in the header when
+    #   requesting any of the secured resources as follows:
+    #
+    #   # => Authorization: Bearer [token]
+    #
+    class AccessToken < Base
+      attr_accessor :token, :type, :expires_in
+
+      # @param [Hash] params -
+      #   Params required for token initialization
+      #
+      # @option params [String] :token -
+      #   The generated access token.
+      #
+      # @option params [String] :type -
+      #   Token authorization type. This value will always be "Bearer".
+      #
+      # @option params [Integer] :expires_in -
+      #   The number of seconds left before the token becomes invalid.
+      #
+      def initialize(params)
+        @current_session_ts = Time.now.utc
+
+        super(params)
+      end
+
+      # Check token validity(expired or not)
+      #
+      # @return [Boolean]
+      #
+      def valid?
+        (Time.now - @current_session_ts).to_i < expires_in
+      end
+    end
+  end
+end

--- a/lib/basiq/entities/account.rb
+++ b/lib/basiq/entities/account.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+module Basiq
+  module Entities
+    # Basiq::Entities::Account
+    #
+    #   The account object represents an account held with a
+    #   financial institution (e.g. a savings account).
+    #   You can use this object to retrieve specific account details such as
+    #   the account number, balance and available funds.
+    #
+    class Account < Base
+      attr_accessor :id, :type, :links, :self,
+                    :account_no, :name, :currency,
+                    :balance, :available_funds, :last_updated,
+                    :class, :status, :institution, :connection, :transactions
+
+      # @param [Hash] params
+      #
+      # @option params [String] :id -
+      #   Uniquely identifies the account.
+      #
+      # @option params [String] :account_no -
+      #   Full account number.
+      #
+      # @option params [String] :name -
+      #   Account name as defined by institution or user.
+      #
+      # @option params [String] :currency -
+      #   The currency the funds are stored in, using ISO 4217 standard.
+      #
+      # @option params [String] :balance -
+      #   Amount of funds in the account right now - excluding any pending transactions.
+      #   For a credit card this would be zero or the minus amount spent.
+      #
+      # @option params [String] :available_funds -
+      #   Funds that are available to an account holder for withdrawal or other use.
+      #   This may include funds from an overdraft facility or line of credit,
+      #   as well as funds classified as the available balance,
+      #   such as from cleared and existing deposits.
+      #
+      # @option params [String, DateTime] :last_updated -
+      #   Timestamp of last update, UTC, RFC 3339 format e.g. "2017-09-28T13:39:33.144Z"
+      #
+      # @option params [Hash] :class -
+      #   Identifies the account type and product as defined by institution.
+      #
+      #   Possible values for account type are:
+      #
+      #     - credit-card - a credit card account.
+      #     - foreign - a foreign cash account e.g. travel card.
+      #     - insurance - an insurance account.
+      #     - investment - a investment account.
+      #     - loan - a loan (e.g. personal or business loan).
+      #     - mortgage - a home loan.
+      #     - savings - savings account.
+      #     - term-deposit - a term deposit account.
+      #     - transaction - a keycard or chequing account.
+      #     - unknown
+      #
+      #   product - A property of class object. Product name as defined by institution.
+      #   meta - A property of class object. Meta data related to account type.
+      #
+      #   For account type mortgagemeta data include:
+      #
+      #     - accountNumber - full account number.
+      #     - interestType - loan interest rate type fixed rate or variable
+      #     - repaymentType - loan repayment type interest only or interest and principal
+      #     - repaymentFrequency - loan repayment frequency weekly, fortnightly or monthly
+      #     - nextInstalmentDate - next loan instalment date
+      #     - instalmentAmount - next loan instalment amount
+      #     - interestRate - current loan percentage interest rate - 4.8% p.a expressed as "4.08"
+      #     - endDate - loan maturity date
+      #     - fee - loan service fees "500.00" or text such as "waived"
+      #     - availableRedraw - loan paid off that is available for redraw (variable loans only)
+      #     - offsetAccountNumber - account linked to loan account, balance is offset against loan.
+      #
+      # @option params [String] :status -
+      #   Indicates the account status. Possible values include:
+      #
+      #     - available newest account data is available.
+      #     - unavailable account information is no longer available
+      #
+      # @option params [String] :institution -
+      #   The id of the institution resource the account originated from.
+      #
+      # @option params [String] :connection -
+      #   The id of the connection resource that was used to retrieve the account.
+      #
+      def initialize(params)
+        super(params)
+      end
+    end
+  end
+end

--- a/lib/basiq/entities/base.rb
+++ b/lib/basiq/entities/base.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Basiq
+  module Entities
+    # Basiq::Entities::Base
+    #
+    #   [DESCRIPTION]
+    #
+    class Base
+      # @param [Hash] attributes - (optional, nil) Attributes in hash
+      #
+      # @raise [ArgumentError]
+      # @raise [UnknownAttributeError]
+      #
+      # @yield [self] Invokes the block with a instance
+      #
+      def initialize(attributes = nil)
+        assign_attributes(attributes) if attributes
+
+        yield self if block_given?
+      end
+
+      private
+
+      def assign_attributes(new_attributes)
+        unless new_attributes.is_a?(Hash)
+          raise ArgumentError, 'Attributes must be a Hash'
+        end
+
+        return if new_attributes.nil? || new_attributes.empty?
+
+        attributes = stringify_keys(new_attributes)
+        attributes.each { |k, v| _assign_attribute(k, v) }
+      end
+
+      def stringify_keys(hash)
+        hash.transform_keys { |key| key.to_s }
+      end
+
+      def _assign_attribute(attr_name, attr_value)
+        return unless respond_to?("#{attr_name}=")
+
+        public_send("#{attr_name}=", attr_value)
+      end
+    end
+  end
+end

--- a/lib/basiq/entities/connection.rb
+++ b/lib/basiq/entities/connection.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module Basiq
+  module Entities
+    # Basiq::Entities::Connection
+    #
+    #   The connection object is created whenever a user links their
+    #   financial institution with your app.
+    #   Once a connection is successfully created - you can use it to obtain the
+    #   user's latest financial data i.e. accounts and transactions.
+    #   After a connection is successfully established, you can fetch
+    #   data created after this point by refreshing the connection.
+    #   This process ensures on-demand data syncronization between your system
+    #   and Institution itself.
+    #
+    class Connection < Base
+      attr_accessor :id, :links, :type,
+                    :status, :last_used, :login_id,
+                    :password, :security_code, :secondary_login_id,
+                    :accounts, :institution
+
+      # @param [Hash] params
+      #
+      # @option params [String] :id -
+      #   A string that uniquely identifies the user connection.
+      #
+      # @option params [String] :login_id -
+      #   User's institution login ID. This value cannot be read.
+      #
+      # @option params [String] :password -
+      #   User's institution password. This value cannot be read.
+      #
+      # @option params [String] :security_code -
+      #   (conditional)User's institution security code.
+      #   This value cannot be read.
+      #
+      # @option params [String] :secondary_login_id -
+      #   (conditional)User's institution secondary login id.
+      #   This value cannot be read.
+      #
+      # @option params [String] :status -
+      #   Indicates the connection status.
+      #   Possible values include:
+      #
+      #     - active the connection is valid (is working!)
+      #     - invalid the connection is no longer valid and requires the user to update their logon details
+      #
+      # @option params [String, DateTime] :last_used -
+      #   UTC Date and Time of when the connection was last used, in RFC 3339 format.
+      #
+      # @option params [Basiq::Entities::Institution] :institution -
+      #   The institution the connection relates to.
+      #
+      # @option params [Array<Basiq::Entities::Accounts>] :accounts -
+      #   User's accounts in this institution.
+      #
+      #
+      def initialize(params)
+        super(params)
+      end
+
+      def to_h
+        {
+          id: id,
+          status: status,
+          last_used: last_used
+        }
+      end
+    end
+  end
+end

--- a/lib/basiq/entities/image.rb
+++ b/lib/basiq/entities/image.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Basiq
+  module Entities
+    # Basiq::Entities::Image
+    #
+    #   Represents Image object
+    #
+    class Image < Base
+      attr_accessor :type, :colors, :links
+
+      def initialize(params)
+        super(params)
+      end
+    end
+  end
+end

--- a/lib/basiq/entities/institution.rb
+++ b/lib/basiq/entities/institution.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+module Basiq
+  module Entities
+    # Basiq::Entities::Institution
+    #
+    #   The institution object represents a financial institution
+    #   (such as a bank, credit union etc).
+    #   You can use this object to obtain a list of supported institutions or
+    #   to get general information about each institution.
+    #
+    class Institution < Base
+      attr_accessor :id, :type, :links,
+                    :name, :short_name, :country,
+                    :institution_type, :service_type, :service_name, :tier,
+                    :login_id_caption, :password_caption, :logo
+
+      # @param [Hash] params - Institution attributes
+      #
+      # @option params [String] :id -
+      #   A string that uniquely identifies the institution.
+      #
+      # @option params [String] :name -
+      #   The full name of the institution.
+      #
+      # @option params [String] :short_name -
+      #   Short name of institution.
+      #
+      # @option params [String] :institution_type -
+      #   An enum identifying the institution type. Possible values include:
+      #     - Bank
+      #     - Bank (Foreign)
+      #     - Test Bank
+      #     - Credit Union
+      #     - Financial Services
+      #     - Superannuation
+      #
+      # @option params [String] :country -
+      #   Country in which this institution operates.
+      #   English short name used by ISO 3166/MA.
+      #
+      # @option params [String] :service_name -
+      #   Name of the supported service (as defined by the institution).
+      #
+      # @option params [String] :service_type -
+      #   An enum identifying the service type. Possible values include:
+      #     - Personal Banking
+      #     - Business Banking
+      #     - Card Access
+      #     - Test
+      #
+      # @option params [Hash] :logo -
+      #   Object that contains main colors, and URLs of
+      #   square and full institution logo image, returned in SVG format.
+      #
+      # @option params [String] :tier -
+      #   Institution's tier - a representation of it's business and
+      #   market share in the relevant country/region.
+      #   Values range from 1 to 4. Tier 1 are Institutions with the
+      #   highest impact on the market.
+      #   For example, CBA is a Tier 1 Bank, Suncorp is a Tier 2 Bank, etc.
+      #
+      # @option params [String] :login_id_caption -
+      #   Caption used by institution to request login id.
+      #
+      # @option params [String] :password_caption -
+      #   Caption used by institution to request password.
+      #
+      def initialize(params)
+        super(params)
+      end
+
+      def to_h
+        {
+          id: id,
+          name: name,
+          short_name: short_name,
+          country: country,
+          service_name: service_name,
+          service_type: service_type,
+          institution_type: institution_type,
+          tier: tier,
+          login_id_caption: login_id_caption,
+          password_caption: password_caption,
+          logo: logo
+        }
+      end
+    end
+  end
+end
+

--- a/lib/basiq/entities/job.rb
+++ b/lib/basiq/entities/job.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module Basiq
+  module Entities
+    # Basiq::Entities::Job
+    #
+    #   Some of the services provided by Basiq are quite resource intensive,
+    #   and may take a little time to process.
+    #   To ensure that we provide a pleasant experience to you and
+    #   your end-users, and that we avoid timeouts of long running connections
+    #   to our server - we will handle these processes (jobs) asynchronously.
+    #
+    #   When an asynchronous operation is initiated (e.g. refreshing a connection)
+    #   the Basiq server will create a job resource and return
+    #   a status code of 202 - Accepted along with the job details (in the body).
+    #   You can then query the job url to track its progress.
+    #
+    #
+    #   Every step of the job has a status property that depicts its current state.
+    #   The possible status values for each step are as follows:
+    #
+    #     1. pending      - The job has been created and is waiting to be started.
+    #     2. in-progress  - The job has started and is currently processing.
+    #     3. success      - The job has successfully completed.
+    #     4. failed       - The job has failed.
+    #
+    #   Depending on the job being executed, some jobs will have multiple steps
+    #   which need to be executed, for e.g. refreshing a
+    #   connection requires the following steps to be completed:
+    #
+    #     1. Establish successful authentication with institution
+    #     2. Fetch latest list of accounts
+    #     3. Fetch latest list of transactions
+    #
+    #   You can keep track of the steps that have been completed by observing the
+    #   results array property.
+    #   As each step is successfully completed, its status will be
+    #   updated and a result object with the link to the affected resource will be present.
+    #   In the event that a step has failed, the result object will contain an embedded error object.
+    #
+    class Job < Base
+      attr_accessor :id, :type, :links, :steps, :created, :updated, :self
+
+      # @param [Hash] params
+      #
+      # @option params [String] :id -
+      #   A string that uniquely identifies the job.
+      #
+      # @option params [String, DateTime] :created -
+      #   The date time when the job was created.
+      #
+      # @option params [String, DateTime] :updated -
+      #   The date time when the job was last updated.
+      #
+      # @option params [Array<Hash>] :steps -
+      #   List of steps that need to be completed.
+      #   With the following properties:
+      #
+      #     - title - Name of the step the job needs to complete.
+      #     - status - Step status: pending, in-progress, success, failed.
+      #     - result - List of URLs of the updated (or created) resources.
+      #                Otherwise if a step failed contains an error response.
+      #
+      def initialize(params)
+        super(params)
+      end
+    end
+  end
+end

--- a/lib/basiq/entities/transaction.rb
+++ b/lib/basiq/entities/transaction.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+module Basiq
+  module Entities
+    # Basiq::Entities::Transaction
+    #
+    #   A transaction object is created whenever money is debited or credited from a particular account.
+    #
+    #   NOTE : Note that when a connection is refreshed pending transactions will
+    #          receive new id's, whilst posted transactions will
+    #          receive the same id's as before the refresh.
+    #
+    #          Find out more about pending transaction:
+    #          http://docs.basiq.io/the-basiq-platform/what-is-a-pending-transaction
+    #
+    class Transaction < Base
+      attr_accessor :id, :type, :links,
+                    :status, :description,
+                    :post_date, :transaction_date,
+                    :amount, :balance, :bank_category,
+                    :account, :institution, :connection, :direction,
+                    :class, :sub_class
+    end
+
+    # @param [Hash] params
+    #
+    # @option params [String] :id -
+    #   Uniquely identifies the transaction for the connection.
+    #
+    # @option params [String] :status -
+    #   Identifies if a transaction is pending or posted.
+    #   A pending transaction is an approved debit or credit transaction that
+    #   has not been fully processed yet (i.e. has not been posted).
+    #
+    # @option params [String] :description -
+    #   The transaction description as submitted by the institution.
+    #
+    # @option params [String, DateTime] :post_date -
+    #   Date the transaction was posted as provided by the institution
+    #   (this is the same date that appears on a bank statement).
+    #   This value is null if the record is pending. e.g. "2017-11-10T21:46:44Z" or 2017-11-10T00:00:00Z
+    #
+    # @option params [String, DateTime] :transaction_date -
+    #   Date that the user executed the transaction as provided by the istitution.
+    #   Note that not all transactions provide this value (varies by institution) e.g. "2017-11-10T00:00:00Z"
+    #
+    # @option params [String] :amount -
+    #   Transaction amount. Outgoing funds are expressed as negative values.
+    #
+    # @option params [String] :balance -
+    #   Value of the account balance at time the transaction was completed.
+    #
+    # @option params [String] :bank_category -
+    #   Category as defined by the institution itself.
+    #   Note that not all institutions define this category.
+    #
+    # @option params [String] :direction -
+    #   Identifies if the transaction is of debit or credit type.
+    #
+    # @option params [String] :class -
+    #   Describes the class(type) of transaction.
+    #   Possible values depend on the direction field, and include:
+    #
+    #   Debit Classes:
+    #
+    #     - bank-fee - a fee incurred by the user from their bank e.g. ATM withdrawal fee.
+    #     - payment - payment made to a merchant.
+    #     - cash-withdrawal - funds withdrawn via atm facility.
+    #     - transfer - funds transferred to an account.
+    #
+    #   Credit Classes:
+    #
+    #     - refund - funds returned due to refund.
+    #     - direct-credit - funds deposited into an account.
+    #     - interest - interest earned.
+    #     - transfer - funds received from an account.
+    #
+    # @option params [Hash] :sub_class -
+    #   Attribute includes a code and title property.
+    #   The subClass attribute will only return values for payment transactions (i.e. will be empty for all others)
+    #
+    # @option params [String] :account -
+    #   The id of the account resource the transaction belongs to.
+    #
+    # @option params [String] :institution -
+    #   The id of the institution resource the transaction originated from.
+    #
+    # @option params [String] :connection -
+    #   The id of the connection resource that was used to retrieve the transaction.
+    #
+    # @option params [Hash] :links -
+    #   A links object containing related objects
+    #
+    def initialize(params)
+      super(params)
+    end
+  end
+end

--- a/lib/basiq/entities/user.rb
+++ b/lib/basiq/entities/user.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Basiq
+  module Entities
+    # Basiq::Entities::User
+    #
+    #   The user object represents an end-user of your application.
+    #   This object encapsulates all of the financial details of an
+    #   individual (such as list of accounts and transactions) along with
+    #   the relationships that they hold with each institution (i.e. connections).
+    #
+    #   Use this object to keep your list of users in sync with the Basiq server.
+    #   Once a user ceases to use your application,
+    #   it is strongly recommended that the user object is deleted.
+    #
+    class User < Base
+      attr_accessor :id, :type, :links, :email, :mobile, :name, :connections
+
+      # @param [Hash] params - User attributes
+      #
+      # @option params [String] :id -
+      #   A string that uniquely identifies the user.
+      #
+      # @option params [String] :email -
+      #   The end-users email address.
+      #
+      # @option params [String] :mobile -
+      #   The end-users mobile number.
+      #
+      def initialize(params)
+        super(params)
+      end
+
+      def to_h
+        {
+          id: id,
+          email: email,
+          mobile: mobile,
+          name: name
+        }
+      end
+    end
+  end
+end

--- a/lib/basiq/filter_builder.rb
+++ b/lib/basiq/filter_builder.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+module Basiq
+  # Basiq::FilterBuilder
+  #
+  #   Used to build filters query.
+  #
+  #   Filtering a collection resource is conducted via the
+  #   filter query parameter using the following notation:
+  #
+  #     ?filter=[property].[condition]([value])
+  #
+  #
+  #   NOTE : All filter values should be URL encoded!
+  #          Examples have not url encoded the filters.
+  #          You will need to ensure that the filter values are
+  #          url encoded before calling the resource.
+  #
+  class FilterBuilder
+    attr_accessor :filters
+
+    def initialize
+      @filters = []
+    end
+
+    # "Equals" filter
+    #
+    # @param [String] field - The field to which the filter is applied
+    # @param [String] value - The value to filter on
+    #
+    # Example : ?filter=account.id.eq('s55bf3')
+    #
+    # @return [Self]
+    #
+    def eq(field, value)
+      filters << "#{field}.eq('#{value}')"
+
+      self
+    end
+
+    # "Greater than" filter
+    #
+    # @param [String] field - The field to which the filter is applied
+    # @param [String] value - The value to filter on
+    #
+    # Example : ?filter=transaction.postDate.gt('2018-01-28')
+    #
+    # @return [Self]
+    #
+    def gt(field, value)
+      filters << "#{field}.gt('#{value}')"
+      self
+    end
+
+    # "Greater than or equal to" filter
+    #
+    # @param [String] field - The field to which the filter is applied
+    # @param [String] value - The value to filter on
+    #
+    # Example : ?filter=transaction.postDate.gteq('2018-01-28')
+    #
+    # @return [Self]
+    #
+    def gteq(field, value)
+      filters << "#{field}.gteq('#{value}')"
+      self
+    end
+
+    # "Less than" filter
+    #
+    # @param [String] field - The field to which the filter is applied
+    # @param [String] value - The value to filter on
+    #
+    # Example : ?filter=transaction.postDate.lt('2018-01-28')
+    #
+    # @return [Self]
+    #
+    def lt(field, value)
+      filters << "#{field}.lt('#{value}')"
+      self
+    end
+
+    # "Less than or equal to" filter
+    #
+    # @param [String] field - The field to which the filter is applied
+    # @param [String] value - The value to filter on
+    #
+    # Example : ?filter=transaction.postDate.lteq('2018-01-28')
+    #
+    # @return [Self]
+    #
+    def lteq(field, value)
+      filters << "#{field}.lteq('#{value}')"
+      self
+    end
+
+    # "Between two values" filter - used for date range filtering.
+    #
+    # NOTE :  Values are inclusive.
+    #
+    # @param [String] field         - The field to which the filter is applied
+    # @param [String] first_value   - The first value in the range to filter on
+    # @param [String] second_value  - The last value in the range to filter on
+    #
+    # Example : ?filter=transaction.postDate.bt('2017-09-28','2018-01-30').
+    #
+    # @return [Self]
+    #
+    def bt(field, first_value, second_value)
+      filters << "#{field}.bt('#{first_value}', '#{second_value}')"
+      self
+    end
+
+    # Build filter expression and return query string
+    #
+    # Example : ?filter=transaction.postDate.bt('2018-01-28','2018-02-27'),account.id.eq('aef3g')
+    #
+    # @return [String]
+    #
+    def build
+      "filter=#{filters.join(',')}"
+    end
+  end
+end

--- a/lib/basiq/parser.rb
+++ b/lib/basiq/parser.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+module Basiq
+  # Basiq::Parser
+  #
+  #   Used to transform(convert) raw data from API response to
+  #   the Basiq entities models
+  #
+  class Parser
+    ENTITIES = {
+      'account' => Basiq::Entities::Account,
+      'transaction' => Basiq::Entities::Transaction,
+      'user' => Basiq::Entities::User,
+      'connection' => Basiq::Entities::Connection,
+      'institution' => Basiq::Entities::Institution,
+      'image' => Basiq::Entities::Image,
+      'job' => Basiq::Entities::Job
+    }.freeze
+
+    # Transform raw response data to the Basiq entity
+    #   (may return array if list request was made)
+    #
+    # @param [Hash] data - Raw data from the API request
+    #
+    # @return [Array<Basiq::Entities::Base>, Basiq::Entities::Base]
+    #
+    def parse(data)
+      transformed_data = transform_keys(data)
+
+      convert(transformed_data)
+    end
+
+    private
+
+    def convert(data)
+      if data[:type] == 'list'
+        convert_to_list(data)
+      else
+        convert_to_entity(data)
+      end
+    end
+
+    def convert_to_list(data)
+      data[:data].compact.map { |obj| convert_to_entity(obj) }
+    end
+
+    def convert_to_entity(data)
+      attributes = data.each_with_object({}) do |(key, value), hash|
+        hash[key] = entity?(value, key) ? convert(value) : value
+      end
+
+      ENTITIES[data[:type]].new(attributes)
+    end
+
+    def entity?(value, key)
+      value.is_a?(Hash) && value.key?(:type) && key != :class
+    end
+
+    def transform_keys(data)
+      deep_transform_keys(data) { |key| underscore(key.to_s).to_sym }
+    end
+
+    def deep_transform_keys(object, &block)
+      case object
+      when Hash
+        object.each_with_object({}) do |(key, value), result|
+          result[yield(key)] = deep_transform_keys(value, &block)
+        end
+      when Array
+        object.map { |e| deep_transform_keys(e, &block) }
+      else
+        object
+      end
+    end
+
+    def underscore(camel_cased_word)
+      camel_cased_word.gsub(/::/, '/')
+                      .gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
+                      .gsub(/([a-z\d])([A-Z])/, '\1_\2')
+                      .tr('-', '_')
+                      .downcase
+    end
+  end
+end

--- a/lib/basiq/query.rb
+++ b/lib/basiq/query.rb
@@ -1,0 +1,147 @@
+# frozen_string_literal: true
+
+module Basiq
+  # Basiq::Query
+  #
+  #   Used to build and execute request to the basiq API
+  #
+  class Query
+    attr_reader :headers
+
+    def initialize(endpoint, headers, parser, filter_builder = nil)
+      @parser = parser
+      @filter_builder = filter_builder || FilterBuilder.new
+
+      @root_endpoint = endpoint
+      @headers = headers
+    end
+
+    %i[eq gt gteq lt lteq].each do |method|
+      # Filters
+      #
+      #   - "Equals" filter
+      #   - "Greater than" filter
+      #   - "Greater than or equal to" filter
+      #   - "Less than" filter
+      #   - "Less than or equal to" filter
+      #
+      # @param [String] field - The field to which the filter is applied
+      # @param [String] value - The value to filter on
+      #
+      define_method(method) do |field, value|
+        @filter_builder.public_send(method, field, value)
+
+        self
+      end
+    end
+
+    # "Between two values" filter - used for date range filtering.
+    #
+    # NOTE :  Values are inclusive.
+    #
+    # @param [String] field         - The field to which the filter is applied
+    # @param [String] first_value   - The first value in the range to filter on
+    # @param [String] second_value  - The last value in the range to filter on
+    #
+    # @return [Self]
+    #
+    def bt(field, first_value, second_value)
+      @filter_builder.bt(field, first_value, second_value)
+
+      self
+    end
+
+    # Retrieves the details of an existing resource.
+    # You need only supply the resource unique identifier.
+    #
+    # @param [String] resource_id - Resource unique identifier
+    #
+    # @return [Basiq::Entities::Base]
+    #
+    def find_by_id(resource_id)
+      endpoint = "/#{@root_endpoint}/#{resource_id}"
+
+      response = Basiq::Request.new(endpoint).get(headers: headers)
+
+      @parser.parse(response.body)
+    end
+
+    # Use this collection to retrieve a list of institutions.
+    # Each entry in the array is a separate institution object.
+    #
+    # @return [Array<Basiq::Entities::base]
+    #
+    def retrieve
+      filters = @filter_builder.build
+
+      endpoint = @root_endpoint
+      endpoint = "#{@root_endpoint}?#{filters}" if filters.present?
+
+      response = Basiq::Request.new(endpoint).get(headers: headers)
+
+      @parser.parse(response.body)
+    end
+
+    # Use this to create a new resource object.
+    #
+    # Returns the resource object if the update succeeded.
+    # Returns an error if update parameters are invalid.
+    #
+    # @param [Hash] params - Particular resource object parameters
+    #
+    # @raise [Basiq::ServiceError]
+    #
+    # @return [Basiq::Entities::Base]
+    #
+    def create(params)
+      response = Basiq::Request
+                 .new(@root_endpoint)
+                 .post(body: params, headers: headers)
+
+      @parser.parse(response.body)
+    end
+
+    # Updates the specified resource object by setting the values of the parameters passed.
+    # Any parameters not provided will be left unchanged.
+    #
+    # Returns the resource object if the update succeeded.
+    # Returns an error if update parameters are invalid.
+    #
+    # @param [String] resource_id - Resource unique identifier
+    # @param [Hash] params - Particular resource object parameters
+    #
+    # @raise [Basiq::ServiceError]
+    #
+    # @return [Basiq::Entities::Base]
+    #
+    def update(resource_id, params)
+      endpoint = "/#{@root_endpoint}/#{resource_id}"
+
+      response = Basiq::Request
+                 .new(endpoint)
+                 .post(body: params, headers: headers)
+
+      @parser.parse(response.body)
+    end
+
+    # Permanently deletes a user along with all of their associated connection details.
+    # You need only supply the unique user identifier that was returned upon user creation.
+    #
+    # Returns an empty body if the delete succeeded.
+    # Otherwise, this call returns an error in the event of a failure.
+    #
+    # NOTE : Note that this action cannot be undone!
+    #
+    # @param [String] resource_id - Resource unique identifier
+    #
+    # @raise [Basiq::ServiceError]
+    #
+    # @return [nil]
+    #
+    def delete(resource_id)
+      endpoint = "/#{@root_endpoint}/#{resource_id}"
+
+      Basiq::Request.new(endpoint).delete(headers: headers)
+    end
+  end
+end

--- a/lib/basiq/request.rb
+++ b/lib/basiq/request.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+module Basiq
+  # Basiq::Request
+  #
+  #   [DESCRIPTION]
+  #
+  class Request
+    TIMEOUT = 60
+    OPEN_TIMEOUT = 60
+    API_ENDPOINT = 'https://au-api.basiq.io'
+
+    def initialize(endpoint)
+      @endpoint = endpoint
+    end
+
+    def post(params: nil, headers: nil, body: nil)
+      response = rest_client.post(@endpoint) do |request|
+        configure_request(
+          request: request,
+          params: params,
+          headers: headers,
+          body: MultiJson.dump(body)
+        )
+      end
+      parse_response(response)
+    rescue StandardError => e
+      handle_error(e)
+    end
+
+    def get(params: nil, headers: nil)
+      response = rest_client.get(@endpoint) do |request|
+        configure_request(request: request, params: params, headers: headers)
+      end
+      parse_response(response)
+    rescue StandardError => e
+      handle_error(e)
+    end
+
+    def delete(params: nil, headers: nil)
+      response = rest_client.delete(@endpoint) do |request|
+        configure_request(request: request, params: params, headers: headers)
+      end
+      parse_response(response)
+    rescue StandardError => e
+      handle_error(e)
+    end
+
+    private
+
+    def configure_request(request: nil, params: nil, headers: nil, body: nil)
+      return unless request
+
+      request.params.merge!(params) if params
+
+      request.headers['Content-Type'] = 'application/json'
+      request.headers['basiq-version'] = '2.0'
+      request.headers.merge!(headers) if headers
+
+      request.body = body if body
+
+      request.options.timeout = TIMEOUT
+      request.options.open_timeout = OPEN_TIMEOUT
+    end
+
+    def rest_client
+      Faraday.new(API_ENDPOINT, ssl: { version: 'TLSv1_2' }) do |faraday|
+        faraday.response :raise_error
+        faraday.adapter(Faraday.default_adapter)
+      end
+    end
+
+    def parse_response(response)
+      return nil if response.body.nil? || response.body.empty?
+
+      begin
+        headers = response.headers
+        body = MultiJson.load(response.body, symbolize_keys: true)
+
+        Response.new(headers: headers, body: body)
+      rescue MultiJson::ParseError
+        error = ServiceError.new(
+          "Unparseable response: #{response.body}",
+          title: 'UNPARSEABLE_RESPONSE', status_code: 500
+        )
+
+        raise error
+      end
+    end
+
+    def handle_error(error)
+      error_params = {}
+
+      begin
+        if error.is_a?(Faraday::Error::ClientError) && error.response
+          error_params[:status_code] = error.response[:status]
+          error_params[:raw_body] = error.response[:body]
+
+          parsed_response = MultiJson.load(error.response[:body])
+
+          if parsed_response
+            error_params[:body] = parsed_response
+
+            if parsed_response['title']
+              error_params[:title] = parsed_response['title']
+            end
+
+            if parsed_response['detail']
+              error_params[:detail] = parsed_response['detail']
+            end
+          end
+
+        end
+      rescue MultiJson::ParseError
+      end
+
+      error_to_raise = ServiceError.new(error.message, error_params)
+
+      raise error_to_raise
+    end
+  end
+end

--- a/lib/basiq/response.rb
+++ b/lib/basiq/response.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Basiq
+  # Basiq::Response
+  #
+  #   Used to represent basiq api response
+  #     (raw body and headers information)
+  #
+  class Response
+    attr_accessor :body, :headers
+
+    def initialize(body: {}, headers: {})
+      @body = body
+      @headers = headers
+    end
+  end
+end

--- a/lib/basiq/service_error.rb
+++ b/lib/basiq/service_error.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+module Basiq
+  # Basiq::ServiceError
+  #
+  #   Used to represent an error that may occur when performing a request to the basiq API
+  #
+  class ServiceError < StandardError
+    attr_reader :title, :detail, :body, :raw_body, :status_code
+
+    # @param [String] message - (optional, '') Message to describe error
+    # @param [Hash] params - (optional, {}) Additional error information
+    #
+    # @option params [String] :title        - Error summary
+    # @option params [String] :detail       - Error detailed description
+    # @option params [String] :body         - Parsed body from response
+    # @option params [String] :raw_body     - Raw body from response
+    # @option params [String] :status_code  - Http status code
+    #
+    def initialize(message = '', params = {})
+      @title       = params[:title]
+      @detail      = params[:detail]
+      @body        = params[:body]
+      @raw_body    = params[:raw_body]
+      @status_code = params[:status_code]
+
+      super(message)
+    end
+
+    def to_s
+      "#{super} #{instance_variables_to_s}"
+    end
+
+    private
+
+    def instance_variables_to_s
+      %i[title detail body raw_body status_code].map do |attr|
+        attr_value = send(attr)
+
+        "@#{attr}=#{attr_value.inspect}"
+      end.join(', ')
+    end
+  end
+end

--- a/spec/basiq/authorizer_spec.rb
+++ b/spec/basiq/authorizer_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Basiq::Authorizer do
+  let(:endpoint) { 'https://au-api.basiq.io/token' }
+
+  before do
+    stub_request(:post, endpoint).to_return(body: body, status: status)
+  end
+
+  describe '#obtain_token' do
+    subject { described_class.new('api_key').obtain_token }
+
+    context 'valid response' do
+      let(:body) do
+        '{"access_token":"ACCESS_TOKEN","token_type":"Bearer","expires_in":3600}'
+      end
+
+      let(:status) { 200 }
+
+      it { expect(subject).to be_an(Basiq::Entities::AccessToken) }
+
+      it { expect(subject.token).to eq('ACCESS_TOKEN') }
+
+      it { expect(subject.type).to eq('Bearer') }
+
+      it { expect(subject.expires_in).to eq(3600) }
+    end
+
+    context 'error status' do
+      let(:body) do
+        "{
+          \"type\": \"list\",
+          \"correlationId\": \"bd1183d9-c9d8-11e7-909a-6789bfc80ac5\",
+          \"data\": [
+            {
+              \"type\": \"error\",
+              \"code\": \"parameter-not-supplied\",
+              \"title\": \"Required parameter not supplied\",
+              \"detail\": \"Institution ID  parameter is required.\",
+              \"source\": {
+                \"pointer\": \"connection/institution/id\",
+                \"parameter\": \"id\"
+              }
+            }
+          ]
+        }"
+      end
+
+      let(:status) { 400 }
+
+      it { expect { subject }.to raise_error(Basiq::ServiceError) }
+    end
+
+    context 'invalid body' do
+      let(:body)    { 'so-so' }
+      let(:status)  { 200 }
+
+      it { expect { subject }.to raise_error(Basiq::ServiceError) }
+    end
+
+    context 'empty body' do
+      let(:body)    { '' }
+      let(:status)  { 200 }
+
+      it { expect(subject).to be_nil }
+    end
+  end
+end

--- a/spec/basiq/client_spec.rb
+++ b/spec/basiq/client_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Basiq::Client do
+  before do
+    stub_request(:get, "https://au-api.basiq.io/#{endpoint}")
+      .to_return(body: body, status: status)
+
+    stub_request(:post, "https://au-api.basiq.io/#{endpoint}")
+      .to_return(body: body, status: status)
+
+    allow_any_instance_of(described_class).to(
+      receive(:headers).and_return('Authorization' => 'Bearer')
+    )
+  end
+
+  describe '.users' do
+    describe '.find_by_id' do
+      subject { described_class.new('wat').users.find_by_id(user_id) }
+
+      let(:user_id) { 1 }
+      let(:endpoint) { "users/#{user_id}" }
+
+      let(:body) do
+        "{
+            \"type\": \"user\",
+            \"id\": \"ea3a81\",
+            \"email\": \"gavin@hooli.com\",
+            \"mobile\": \"+61410888666\",
+            \"connections\": {
+              \"type\": \"list\",
+              \"count\": 1,
+              \"data\": [
+                {
+                  \"type\": \"connection\",
+                  \"id\": \"aaaf2c3b\",
+                  \"links\": {
+                    \"self\": \"https://au-api.basiq.io/users/ea3a81/connections/aaaf2c3b\"
+                  }
+                }
+              ]
+            },
+            \"links\": {
+              \"self\": \"https://au-api.basiq.io/users/ea3a81\",
+              \"connections\": \"https://au-api.basiq.io/users/ea3a81/connections\"
+            }
+          }"
+      end
+
+      let(:status) { 200 }
+
+      it { expect(subject).to be_an(Basiq::Entities::User) }
+
+      it { expect(subject.id).to eq('ea3a81') }
+
+      it { expect(subject.email).to eq('gavin@hooli.com') }
+
+      it { expect(subject.mobile).to eq('+61410888666') }
+
+      it { expect(subject.connections).to be_an(Array) }
+    end
+
+    describe '.create' do
+      subject { described_class.new('wat').users.create(params) }
+
+      let(:endpoint) { 'users' }
+
+      let(:body) do
+        "{
+          \"type\": \"user\",
+          \"id\": \"ea3a81\",
+          \"email\": \"gavin@hooli.com\",
+          \"mobile\": \"+61410888666\",
+          \"links\": {
+            \"self\": \"https://au-api.basiq.io/users/ea3a81\"
+          }
+        }"
+      end
+      let(:status) { 200 }
+
+      let(:params) do
+        {
+          email: 'gavin@hooli.com',
+          mobile: '+61410888666'
+        }
+      end
+
+      it { expect(subject).to be_an(Basiq::Entities::User) }
+
+      it { expect(subject.id).to eq('ea3a81') }
+
+      it { expect(subject.email).to eq('gavin@hooli.com') }
+
+      it { expect(subject.mobile).to eq('+61410888666') }
+    end
+  end
+end

--- a/spec/basiq/entities/access_token_spec.rb
+++ b/spec/basiq/entities/access_token_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Basiq::Entities::AccessToken do
+  describe '.new' do
+    subject do
+      described_class.new(token: 'token', type: 'Bearer', expires_in: 3600)
+    end
+
+    it { expect(subject.token).to eq('token') }
+
+    it { expect(subject.type).to eq('Bearer') }
+
+    it { expect(subject.expires_in).to eq(3600) }
+  end
+
+  describe '#valid?' do
+    subject { described_class.new(params).valid? }
+
+    context 'valid token' do
+      let(:params) do
+        { token: 'token', type: 'Bearer', expires_in: 3600 }
+      end
+
+      it { expect(subject).to be(true) }
+    end
+
+    context 'valid token' do
+      let(:params) do
+        { token: 'token', type: 'Bearer', expires_in: 0 }
+      end
+
+      it { expect(subject).to be(false) }
+    end
+  end
+end

--- a/spec/basiq/entities/base_spec.rb
+++ b/spec/basiq/entities/base_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Basiq::Entities::Base do
+  before do
+    class FakeEntity < Basiq::Entities::Base
+      attr_accessor :dump, :status, :name
+    end
+  end
+
+  after { Object.send :remove_const, :FakeEntity }
+
+  describe '.new' do
+    context 'initialize through arguments' do
+      subject { FakeEntity.new(attributes) }
+
+      context 'valid attributes' do
+        let(:attributes) do
+          { status: 'wat', name: 'so', dump: %w[wat so] }
+        end
+
+        it { expect(subject.status).to eq('wat') }
+
+        it { expect(subject.name).to eq('so') }
+
+        it { expect(subject.dump).to eq(%w[wat so]) }
+      end
+
+      context 'invalid attributes type' do
+        let(:attributes) { %w[wat so] }
+
+        it { expect { subject }.to raise_error(ArgumentError) }
+      end
+    end
+
+    context 'initialize through block' do
+      subject { FakeEntity.new(&block) }
+
+      let(:block) do
+        lambda do |r|
+          r.status = 'so'
+          r.name = 'wat'
+          r.dump = %w[so wat]
+        end
+      end
+
+      it { expect(subject.status).to eq('so') }
+
+      it { expect(subject.name).to eq('wat') }
+
+      it { expect(subject.dump).to eq(%w[so wat]) }
+    end
+  end
+end

--- a/spec/basiq/entities/institution_spec.rb
+++ b/spec/basiq/entities/institution_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Basiq::Entities::Institution do
+  let(:entity) do
+    described_class.new(
+      id: 'test',
+      name: 'test',
+      short_name: 'test',
+      country: 'test',
+      service_name: 'test',
+      service_type: 'test',
+      institution_type: 'test',
+      tier: 'test',
+      login_id_caption: 'test',
+      password_caption: 'test',
+      logo: 'test'
+    )
+  end
+
+  describe '#to_h' do
+    subject { entity.to_h }
+
+    it { expect(subject).to be_an(Hash) }
+
+    it 'returns hash with model attribute keys' do
+      expected_keys = %i[
+        id
+        name
+        short_name
+        country
+        service_name
+        service_type
+        institution_type
+        tier
+        login_id_caption
+        password_caption
+        logo
+      ]
+
+      actual_keys = subject.keys
+
+      expect(actual_keys).to match_array(expected_keys)
+    end
+  end
+end

--- a/spec/basiq/entities/user_spec.rb
+++ b/spec/basiq/entities/user_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Basiq::Entities::User do
+  let(:entity) do
+    described_class.new(
+      id: 1,
+      email: 'email@test.test',
+      mobile: '+9778866',
+      name: 'name'
+    )
+  end
+
+  describe '#to_h' do
+    subject { entity.to_h }
+
+    it { expect(subject).to be_an(Hash) }
+
+    it 'returns hash with model attribute keys' do
+      expected_keys = %i[id email mobile name]
+
+      actual_keys = subject.keys
+
+      expect(actual_keys).to match_array(expected_keys)
+    end
+  end
+end

--- a/spec/basiq/filter_builder_spec.rb
+++ b/spec/basiq/filter_builder_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Basiq::FilterBuilder do
+  let(:field) { 'quantity' }
+  let(:value) { 12 }
+
+  describe '#initialize' do
+    subject { described_class.new }
+
+    it { expect(subject.filters).to eq([]) }
+  end
+
+  describe '#eq' do
+    subject { described_class.new.eq(field, value) }
+
+    it { expect(subject).to be_an(described_class) }
+
+    it { expect(subject.filters).to eq(["quantity.eq('12')"]) }
+  end
+
+  describe '#gt' do
+    subject { described_class.new.gt(field, value) }
+
+    it { expect(subject).to be_an(described_class) }
+
+    it { expect(subject.filters).to eq(["quantity.gt('12')"]) }
+  end
+
+  describe '#gteq' do
+    subject { described_class.new.gteq(field, value) }
+
+    it { expect(subject).to be_an(described_class) }
+
+    it { expect(subject.filters).to eq(["quantity.gteq('12')"]) }
+  end
+
+  describe '#lt' do
+    subject { described_class.new.lt(field, value) }
+
+    it { expect(subject).to be_an(described_class) }
+
+    it { expect(subject.filters).to eq(["quantity.lt('12')"]) }
+  end
+
+  describe '#lteq' do
+    subject { described_class.new.lteq(field, value) }
+
+    it { expect(subject).to be_an(described_class) }
+
+    it { expect(subject.filters).to eq(["quantity.lteq('12')"]) }
+  end
+
+  describe '#bt' do
+    let(:first_value) { value }
+    let(:last_value)  { 13 }
+
+    subject { described_class.new.bt(field, first_value, last_value) }
+
+    it { expect(subject).to be_an(described_class) }
+
+    it { expect(subject.filters).to eq(["quantity.bt('12', '13')"]) }
+  end
+
+  describe '#biuld' do
+    let(:builder) { described_class.new }
+
+    subject { builder.build }
+
+    context 'single filter' do
+      before do
+        allow(builder).to receive(:filters).and_return(["quantity.lteq('12')"])
+      end
+
+      it { expect(subject).to be_an(String) }
+
+      it { expect(subject).to eq("filter=quantity.lteq('12')") }
+    end
+
+    context 'multiple filters' do
+      before do
+        allow(builder).to(
+          receive(:filters).and_return(["quantity.lteq('12')", "price.bt('1', '2')"])
+        )
+      end
+
+      it { expect(subject).to be_an(String) }
+
+      it { expect(subject).to eq("filter=quantity.lteq('12'),price.bt('1', '2')") }
+    end
+  end
+end

--- a/spec/basiq/parser_spec.rb
+++ b/spec/basiq/parser_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Basiq::Parser do
+  subject { described_class.new.parse(data) }
+
+  describe '#parse' do
+    context 'institution' do
+      let(:data) do
+        {
+          type: 'institution',
+          id: 'AU00000',
+          name: 'Basiq Test Bank',
+          shortName: 'Basiq Test Bank',
+          institutionType: 'Test Bank',
+          country: 'Australia',
+          serviceName: 'Personal Online Banking',
+          serviceType: 'Test',
+          loginIdCaption: 'Login',
+          passwordCaption: 'Password',
+          tier: '4',
+          logo: {
+            type: 'image',
+            colors: { primary: '#000000' },
+            links: {
+              square: 'https://s3-ap-southeast-2.amazonaws.com/basiq-institutions/AU00000.svg',
+              full: 'https://s3-ap-southeast-2.amazonaws.com/basiq-institutions/AU00000-full.svg'
+            }
+          },
+          links: {
+            self: 'https://au-api.basiq.io/institutions/AU00000'
+          }
+        }
+      end
+
+      let(:model) { Basiq::Entities::Institution }
+
+      it 'returns basiq entity' do
+        expect(subject).to be_an(model)
+      end
+
+      it 'returns model with parsed data' do
+        expect(subject.type).to eq('institution')
+        expect(subject.id).to eq('AU00000')
+        expect(subject.name).to eq('Basiq Test Bank')
+        expect(subject.short_name).to eq('Basiq Test Bank')
+        expect(subject.institution_type).to eq('Test Bank')
+        expect(subject.service_name).to eq('Personal Online Banking')
+        expect(subject.service_type).to eq('Test')
+        expect(subject.login_id_caption).to eq('Login')
+        expect(subject.password_caption).to eq('Password')
+        expect(subject.tier).to eq('4')
+      end
+    end
+
+    context 'institution list' do
+      let(:data) do
+        {
+          type: 'list',
+          size: 89,
+          data: [
+            {
+              type: 'institution',
+              id: 'AU00000',
+              name: 'Basiq Test Bank',
+              shortName: 'Basiq Test Bank',
+              institutionType: 'Test Bank',
+              country: 'Australia',
+              serviceName: 'Personal Online Banking',
+              serviceType: 'Test',
+              loginIdCaption: 'Login',
+              passwordCaption: 'Password',
+              tier: '4',
+              logo: {
+                type: 'image',
+                colors: {
+                  primary: '#000000'
+                },
+                links: {
+                  square: 'https://s3-ap-southeast-2.amazonaws.com/basiq-institutions/AU00000.svg',
+                  full: 'https://s3-ap-southeast-2.amazonaws.com/basiq-institutions/AU00000-full.svg'
+                }
+              },
+              links: {
+                self: 'https://au-api.basiq.io/institutions/AU00000'
+              }
+            },
+            nil
+          ],
+          links: {
+            self: 'https://au-api.basiq.io/institutions'
+          }
+        }
+      end
+      let(:model) { Basiq::Entities::Institution }
+
+      it { expect(subject).to be_an(Array) }
+
+      it { expect(subject.first).to be_an(model) }
+
+      it 'returns model with parsed data' do
+        entity = subject.first
+
+        expect(entity.type).to eq('institution')
+        expect(entity.id).to eq('AU00000')
+        expect(entity.name).to eq('Basiq Test Bank')
+        expect(entity.short_name).to eq('Basiq Test Bank')
+        expect(entity.institution_type).to eq('Test Bank')
+        expect(entity.service_name).to eq('Personal Online Banking')
+        expect(entity.service_type).to eq('Test')
+        expect(entity.login_id_caption).to eq('Login')
+        expect(entity.password_caption).to eq('Password')
+        expect(entity.tier).to eq('4')
+      end
+    end
+  end
+end

--- a/spec/basiq/query_spec.rb
+++ b/spec/basiq/query_spec.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Basiq::Query do
+  context 'filters' do
+    let(:query) do
+      described_class.new('test', 'test', parser, filter_builder)
+    end
+
+    let(:parser) do
+      double('dummy parser', parse: 'wat')
+    end
+
+    let(:filter_builder) do
+      double('dummy builder', eq: self, gt: self, gteq: self, lt: self, lteq: self)
+    end
+
+    describe '#eq' do
+      subject { query.eq('wat', 'so') }
+
+      it { expect(subject).to eq(query) }
+
+      it 'delegates filters to the filter builder' do
+        expect(filter_builder).to receive(:eq).with('wat', 'so')
+        subject
+      end
+    end
+
+    describe '#gt' do
+      subject { query.gt('wat', 'so') }
+
+      it { expect(subject).to eq(query) }
+
+      it 'delegates filters to the filter builder' do
+        expect(filter_builder).to receive(:gt).with('wat', 'so')
+        subject
+      end
+    end
+
+    describe '#gteq' do
+      subject { query.gteq('wat', 'so') }
+
+      it { expect(subject).to eq(query) }
+
+      it 'delegates filters to the filter builder' do
+        expect(filter_builder).to receive(:gteq).with('wat', 'so')
+        subject
+      end
+    end
+
+    describe '#lt' do
+      subject { query.lt('wat', 'so') }
+
+      it { expect(subject).to eq(query) }
+
+      it 'delegates filters to the filter builder' do
+        expect(filter_builder).to receive(:lt).with('wat', 'so')
+        subject
+      end
+    end
+
+    describe '#lteq' do
+      subject { query.lteq('wat', 'so') }
+
+      it { expect(subject).to eq(query) }
+
+      it 'delegates filters to the filter builder' do
+        expect(filter_builder).to receive(:lteq).with('wat', 'so')
+        subject
+      end
+    end
+  end
+end

--- a/spec/basiq/request_spec.rb
+++ b/spec/basiq/request_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Basiq::Request do
+  let(:endpoint) { 'test' }
+  let(:api_root) { 'https://au-api.basiq.io' }
+
+  describe '#get' do
+    subject { described_class.new(endpoint).get }
+
+    it 'surfaces client request exceptions as a Basiq::ServiceError' do
+      exception = Faraday::Error::ClientError.new('the server responded with status 503')
+
+      stub_request(:get, "#{api_root}/#{endpoint}").to_raise(exception)
+
+      expect { subject }.to raise_error(Basiq::ServiceError)
+    end
+
+    it 'surfaces an unparseable response body as a Basiq::ServiceError' do
+      response_values = { status: 503, headers: {}, body: '[foo]' }
+
+      exception = Faraday::Error::ClientError.new('the server responded with status 503', response_values)
+
+      stub_request(:get, "#{api_root}/#{endpoint}").to_raise(exception)
+
+      expect { subject }.to raise_error(Basiq::ServiceError)
+    end
+  end
+
+  describe '#post' do
+    subject { described_class.new(endpoint).post }
+
+    it 'surfaces client request exceptions as a Basiq::ServiceError' do
+      exception = Faraday::Error::ClientError.new('the server responded with status 503')
+
+      stub_request(:post, "#{api_root}/#{endpoint}").to_raise(exception)
+
+      expect { subject }.to raise_error(Basiq::ServiceError)
+    end
+
+    it 'surfaces an unparseable response body as a Basiq::ServiceError' do
+      response_values = { status: 503, headers: {}, body: '[foo]' }
+
+      exception = Faraday::Error::ClientError.new('the server responded with status 503', response_values)
+
+      stub_request(:post, "#{api_root}/#{endpoint}").to_raise(exception)
+
+      expect { subject }.to raise_error(Basiq::ServiceError)
+    end
+  end
+
+  describe '#handle_error' do
+    it "includes status and raw body even when json can't be parsed" do
+      response_values = { status: 503, headers: {}, body: 'A non JSON response' }
+
+      exception = Faraday::Error::ClientError.new('the server responded with status 503', response_values)
+
+      begin
+        described_class.new(endpoint).send(:handle_error, exception)
+      rescue StandardError => boom
+        expect(boom.status_code).to eq 503
+        expect(boom.raw_body).to eq 'A non JSON response'
+      end
+    end
+  end
+end

--- a/spec/basiq/response_spec.rb
+++ b/spec/basiq/response_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Basiq::Response do
+  describe '.new' do
+    subject { described_class.new(params) }
+
+    context 'empty params' do
+      subject { described_class.new }
+
+      it { expect(subject.body).to eq({}) }
+
+      it { expect(subject.headers).to eq({}) }
+    end
+
+    context 'only body param' do
+      let(:params) { { body: { field: 'test' } } }
+
+      it { expect(subject.body).to eq(field: 'test') }
+
+      it { expect(subject.headers).to eq({}) }
+    end
+
+    context 'only headers param' do
+      let(:params) { { headers: { cookie: 'test' } } }
+
+      it { expect(subject.body).to eq({}) }
+
+      it { expect(subject.headers).to eq(cookie: 'test') }
+    end
+
+    context 'body and headers params' do
+      let(:params) do
+        {
+          body: { field: 'test' },
+          headers: { cookie: 'test' }
+        }
+      end
+
+      it { expect(subject.body).to eq(field: 'test') }
+
+      it { expect(subject.headers).to eq(cookie: 'test') }
+    end
+  end
+
+end

--- a/spec/basiq/service_error_spec.rb
+++ b/spec/basiq/service_error_spec.rb
@@ -1,0 +1,82 @@
+require 'spec_helper'
+
+RSpec.describe Basiq::ServiceError do
+
+  describe '.new' do
+    context 'empty params' do
+      subject { described_class.new }
+
+      it { expect(subject.message).to eq(' @title=nil, @detail=nil, @body=nil, @raw_body=nil, @status_code=nil') }
+
+      it { expect(subject.title).to be_nil }
+
+      it { expect(subject.detail).to be_nil }
+
+      it { expect(subject.body).to be_nil }
+
+      it { expect(subject.raw_body).to be_nil }
+
+      it { expect(subject.status_code).to be_nil }
+    end
+
+    context 'only message' do
+      subject { described_class.new('test message') }
+
+      it { expect(subject.message).to eq('test message @title=nil, @detail=nil, @body=nil, @raw_body=nil, @status_code=nil') }
+
+      it { expect(subject.title).to be_nil }
+
+      it { expect(subject.detail).to be_nil }
+
+      it { expect(subject.body).to be_nil }
+
+      it { expect(subject.raw_body).to be_nil }
+
+      it { expect(subject.status_code).to be_nil }
+    end
+
+    context 'message and params' do
+      subject { described_class.new('test message', params) }
+
+      let(:params) do
+        {
+          title: 'title',
+          detail: 'detail',
+          body: 'body',
+          raw_body: 'raw_body',
+          status_code: 'status_code'
+        }
+      end
+
+      it { expect(subject.message).to eq("test message @title=\"title\", @detail=\"detail\", @body=\"body\", @raw_body=\"raw_body\", @status_code=\"status_code\"") }
+
+      it { expect(subject.title).to eq('title') }
+
+      it { expect(subject.detail).to eq('detail') }
+
+      it { expect(subject.body).to eq('body') }
+
+      it { expect(subject.raw_body).to eq('raw_body') }
+
+      it { expect(subject.status_code).to eq('status_code') }
+    end
+  end
+
+  describe '#to_s' do
+    subject { described_class.new(message, params).to_s }
+
+    let(:message) { 'test message' }
+
+    let(:params) do
+      {
+        title: 'title',
+        detail: 'detail',
+        body: 'body',
+        raw_body: 'raw_body',
+        status_code: 'status_code'
+      }
+    end
+
+    it { expect(subject).to eq("test message @title=\"title\", @detail=\"detail\", @body=\"body\", @raw_body=\"raw_body\", @status_code=\"status_code\"") }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,12 +1,20 @@
-require 'bundler/setup'
+require 'rubygems'
+require 'bundler'
+
+$LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
+$LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'basiq'
+
+require 'webmock/rspec'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
-  config.example_status_persistence_file_path = '.rspec_status'
+  # config.example_status_persistence_file_path = '.rspec_status'
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
+
+  config.expose_dsl_globally = true
 
   config.expect_with :rspec do |c|
     c.syntax = :expect


### PR DESCRIPTION
Basiq SDK is a set of tools you can use to easily communicate with Basiq API.(I hope so).
It incapsulates all API requests and data trasformation.
The SDK is organized to mirror the HTTP API's functionality and hierarchy.
The top level object needed for SDKs functionality is the `Basiq::Client` object which requires your API key to be instantiated.

The API of the SDK is manipulated using `Basiq::Query` and `Basiq::Entities`.
Different queries return different entities, but the mapping is not one to one.

Some of the methods support adding filters to them.
The filters are created using the `Basiq::Query` class.
After instantiating the class, you can invoke methods in the form of comparison(field, value).